### PR TITLE
Race Condition fix

### DIFF
--- a/include/configuration.hpp
+++ b/include/configuration.hpp
@@ -18,7 +18,7 @@ constexpr const char* ROS_NODE_NAME = "firmware";
 constexpr const char* ROS_NAMESPACE = "";
 
 // Number of encoder readings to remember when estimating the wheel velocity
-constexpr uint32_t ENCODER_BUFFER_SIZE = 10;
+constexpr uint32_t VELOCITY_ROLLING_WINDOW_SIZE = 10;
 
 // The period (in number of calls to the update() function) at which the battery
 // voltage is probed
@@ -78,25 +78,21 @@ constexpr diff_drive_lib::RobotConfiguration ROBOT_CONFIG = {
     .wheel_FL_conf =
         {
             .motor = MotC,
-            .op_mode = diff_drive_lib::WheelOperationMode::VELOCITY,
-            .velocity_rolling_window_size = ENCODER_BUFFER_SIZE,
+            .op_mode = diff_drive_lib::WheelOperationMode::VELOCITY
         },
     .wheel_RL_conf =
         {
             .motor = MotD,
-            .op_mode = diff_drive_lib::WheelOperationMode::VELOCITY,
-            .velocity_rolling_window_size = ENCODER_BUFFER_SIZE,
+            .op_mode = diff_drive_lib::WheelOperationMode::VELOCITY
         },
     .wheel_FR_conf =
         {
             .motor = MotA,
-            .op_mode = diff_drive_lib::WheelOperationMode::VELOCITY,
-            .velocity_rolling_window_size = ENCODER_BUFFER_SIZE,
+            .op_mode = diff_drive_lib::WheelOperationMode::VELOCITY
         },
     .wheel_RR_conf =
         {
             .motor = MotB,
-            .op_mode = diff_drive_lib::WheelOperationMode::VELOCITY,
-            .velocity_rolling_window_size = ENCODER_BUFFER_SIZE,
+            .op_mode = diff_drive_lib::WheelOperationMode::VELOCITY
         },
 };

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@ board_microros_distro = humble-fictionlab
 board_microros_transport = custom
 board_microros_user_meta = colcon.meta
 lib_deps =
-    https://github.com/fictionlab/diff_drive_lib.git#1.6
+    https://github.com/fictionlab/diff_drive_lib.git#2.0
     https://github.com/fictionlab/micro_ros_platformio#fictionlab-v2
     https://github.com/byq77/encoder-mbed.git#dfac32c
     https://github.com/byq77/drv88xx-driver-mbed.git#61854e8


### PR DESCRIPTION
Applying changes done in LeoCore firmware version for ROS2 that fixed the race condition problem when restarting whole ROS system on the rover.

This PR is on top of another branch that adds to firmware handling of IMU sensor on husarion core2 board.